### PR TITLE
add namedtuple Tab and comment which I commited on the wrong branch

### DIFF
--- a/bread/layout/components/tabs.py
+++ b/bread/layout/components/tabs.py
@@ -36,6 +36,9 @@ class TabPanel(hg.DIV):
         )
 
 
+Tab = collections.namedtuple("Tab", "label content")
+
+
 class Tabs(hg.DIV):
     def __init__(
         self,

--- a/bread/static/design/carbon_design/scss/styles.scss
+++ b/bread/static/design/carbon_design/scss/styles.scss
@@ -145,7 +145,9 @@ fieldset[readonly=true] :disabled {
 }
 
 
-// build a zoned theme that is applied by using a namespace class
+// Sometimes we have elements inside a white box. In this case the elements should be displayed according to the white
+// theme (i.e. gray elements on white background).
+// Therefore we create a zoned theme that is applied by using a namespace class (theme-white).
 .theme-white {
     @include carbon--theme($carbon--theme--white) {
         @include button;


### PR DESCRIPTION
sorry, I did add the comment which you suggested to add (about .theme-white), but I commited it on the wrong branch 😄 

I am only using this version of the namedtuple because I didn't want to add more type hints before adding mypy to the CI. I find `typing.namedtuple` much more readable.

the Tab namedtuple is used here: https://github.com/basxsoftwareassociation/basxconnect/pull/75