### PR TITLE
fix: kwargs are not of type dict

### DIFF
--- a/bread/layout/components/form.py
+++ b/bread/layout/components/form.py
@@ -257,7 +257,7 @@ class FormsetField(hg.Iterator):
         :param str title: Datatable title, automatically generated from form if None
         :param str formname: Name of the surounding django-form object in the context
         :param dict formsetfield_kwargs: Arguments to be passed to the FormSetField constructor
-        :param dict kwargs: Arguments to be passed to the DataTable constructor
+        :param kwargs: Arguments to be passed to the DataTable constructor
         :return: A datatable with inline-editing capabilities
         :rtype: hg.HTMLElement
         """


### PR DESCRIPTION
pycharm tells me dict is not the right annotation...
we would need to put the type of the individual parameters. I think we can just leave it empty, as I beliebe it is not standard to use typing.Any in docstrings. (Once we use typing.* we can just as well use actual type hints.)