### PR TITLE
make "lg" the default breakpoint for columns

### DIFF
--- a/bread/layout/components/grid.py
+++ b/bread/layout/components/grid.py
@@ -24,16 +24,12 @@ class Row(htmlgenerator.DIV):
 
 
 class Col(htmlgenerator.DIV):
-    def __init__(self, *children, breakpoint=None, width=None, **attributes):
+    def __init__(self, *children, breakpoint="lg", width=None, **attributes):
         """
         breakpoint: Can be one of "sm", "md", "lg", "xlg", "max"
         """
         colclass = "bx--col"
-        if breakpoint is not None or width is not None:
-            if width is None:
-                raise ValueError("When breakpoint is given, width is also required")
-            if breakpoint is None:
-                raise ValueError("When width is given, breakpoint is also required")
+        if width is not None:
             colclass += f"-{breakpoint}-{width}"
         attributes["_class"] = attributes.get("_class", "") + f" {colclass}"
         super().__init__(*children, **attributes)


### PR DESCRIPTION
It just feels awkward to have to type "lg" every time since we only currently target deskop anyway.
This PR **doesn't** break any usages of other breakpoints than "lg".