### PR TITLE
fix: weird indent in datatable headers

### DIFF
--- a/bread/layout/components/datatable.py
+++ b/bread/layout/components/datatable.py
@@ -524,7 +524,7 @@ class DataTableColumn(NamedTuple):
         )
 
     def as_header_cell(self, orderingurlparameter="ordering"):
-        headcontent = hg.SPAN(self.header, _class="bx--table-header-label")
+        headcontent = hg.DIV(self.header, _class="bx--table-header-label")
         if self.sortingname:
             headcontent = hg.BUTTON(
                 headcontent,


### PR DESCRIPTION
old:
![image](https://user-images.githubusercontent.com/11404846/144823629-833d0ef4-c888-473c-bd76-21c59339b7b8.png)

new:
![image](https://user-images.githubusercontent.com/11404846/144823574-ac0e60df-4686-4d4a-8115-75f84c9e1d03.png)
