### PR TITLE
add: better API to create links to instance-specific urls

### DIFF
--- a/bread/contrib/reports/urls.py
+++ b/bread/contrib/reports/urls.py
@@ -33,12 +33,12 @@ urlpatterns = [
             ],
             rowactions=[
                 Link(
-                    href=ModelHref(Report, "edit", kwargs={"pk": hg.C("row.pk")}),
+                    href=ModelHref.from_object(hg.C("row"), "edit"),
                     iconname="edit",
                     label=_("Edit"),
                 ),
                 Link(
-                    href=ModelHref(Report, "excel", kwargs={"pk": hg.C("row.pk")}),
+                    href=ModelHref.from_object(hg.C("row"), "excel"),
                     iconname="document",
                     label=_("Excel"),
                 ),

--- a/bread/utils/links.py
+++ b/bread/utils/links.py
@@ -2,7 +2,6 @@ from typing import List, NamedTuple, Optional, Union
 
 import htmlgenerator as hg
 from django.db import models
-from htmlgenerator import Lazy
 
 from .urls import model_urlname
 from .urls import reverse as urlreverse
@@ -60,7 +59,7 @@ class ModelHref(LazyHref):
 
     """
 
-    def __init__(self, model, name, *args, **kwargs):
+    def __init__(self, model: Union[models.Model, hg.Lazy], name: str, *args, **kwargs):
         # if this is an instance of a model, we can extract the pk URL argument directly
         # TODO: instance-specific routes which don't use the pk argument will fail
         if isinstance(model, hg.Lazy):
@@ -72,10 +71,10 @@ class ModelHref(LazyHref):
 
     @staticmethod
     def from_object(
-        object: Union[models.Model, Lazy],
-        name,
+        object: Union[models.Model, hg.Lazy],
+        name: str,
         *args,
-        return_to_current=False,
+        return_to_current: bool = False,
         **kwargs
     ):
         """
@@ -100,7 +99,7 @@ def try_call(var, *args, **kwargs):
 
 
 class Link(NamedTuple):
-    href: Union[str, Lazy]
+    href: Union[str, hg.Lazy]
     label: str
     iconname: Optional[str] = "fade"
     permissions: List[str] = []

--- a/bread/utils/links.py
+++ b/bread/utils/links.py
@@ -57,37 +57,40 @@ class ModelHref(LazyHref):
             models.Person, "edit", kwargs={"pk": hg.C("object.pk")}
         ).resolve(context)
 
+    return_to_current: will add a URL query parameter "next=<current_url" to the generated URL
+
     """
 
-    def __init__(self, model: Union[models.Model, hg.Lazy], name: str, *args, **kwargs):
+    def __init__(
+        self,
+        model: Union[models.Model, hg.Lazy],
+        name: str,
+        *args,
+        return_to_current: bool = False,
+        **kwargs
+    ):
+
         # if this is an instance of a model, we can extract the pk URL argument directly
         # TODO: instance-specific routes which don't use the pk argument will fail
         if isinstance(model, hg.Lazy):
             url = hg.F(lambda c: model_urlname(hg.resolve_lazy(model, c), name))
         else:
             url = model_urlname(model, name)
-
-        super().__init__(url, *args, **kwargs)
-
-    @staticmethod
-    def from_object(
-        object: Union[models.Model, hg.Lazy],
-        name: str,
-        *args,
-        return_to_current: bool = False,
-        **kwargs
-    ):
-        """
-        name: string which denotes an object action name as generated
-              by bread.utils.urls.model_urlname
-        object: instance of a Model, can be lazy
-        return_to_current: will add a URL query parameter "next=<current_url" to the generated URL
-        """
-
         if return_to_current:
             if "query" not in kwargs:
                 kwargs["query"] = {}
             kwargs["query"]["next"] = hg.C("request.get_full_path")
+
+        super().__init__(url, *args, **kwargs)
+
+    @staticmethod
+    def from_object(object: Union[models.Model, hg.Lazy], name: str, *args, **kwargs):
+        """
+        name: string which denotes an object action name as generated
+              by bread.utils.urls.model_urlname
+        object: instance of a Model, can be lazy
+        """
+
         if "kwargs" not in kwargs:
             kwargs["kwargs"] = {}
         kwargs["kwargs"]["pk"] = object.pk

--- a/bread/views/browse.py
+++ b/bread/views/browse.py
@@ -85,7 +85,10 @@ class BrowseView(BreadView, LoginRequiredMixin, PermissionListMixin, ListView):
     """TODO: documentation"""
 
     orderingurlparameter: str = "ordering"
-    objectids_urlparameter: str = "_selected"  # see bread/static/js/main.js:submitbulkaction and bread/layout/components/datatable.py
+
+    # see bread/static/js/main.js:submitbulkaction and bread/layout/components/datatable.py
+    objectids_urlparameter: str = "_selected"
+
     bulkaction_urlparameter: str = "_bulkaction"
     items_per_page_options: Optional[Iterable[int]] = None
     itemsperpage_urlparameter: str = "itemsperpage"
@@ -94,18 +97,21 @@ class BrowseView(BreadView, LoginRequiredMixin, PermissionListMixin, ListView):
     title: Union[hg.BaseElement, str] = ""
     columns: Iterable[Union[str, layout.datatable.DataTableColumn]] = ("__all__",)
     rowclickaction: Optional[Link] = None
+
     # bulkactions: List[(Link, function(request, queryset))]
     # - link.js should be a slug and not a URL
-    # - if the function returns a HttpResponse, the response is returned instead of the browse view result
+    # - if the function returns a HttpResponse, the response is returned
+    #   instead of the browse view result
     bulkactions: Iterable[
         Union[Link, Callable[[HttpRequest, models.QuerySet], Union[None, HttpResponse]]]
     ] = ()
+
     rowactions = ()  # list of links
     backurl = None
     primary_button = None
-    viewstate_sessionkey: Optional[
-        str
-    ] = None  # if set will be used to save the state of the url parameters and restore them on the next call
+
+    # if set will be used to save the state of the url parameters and restore them on the next call
+    viewstate_sessionkey: Optional[str] = None
 
     def __init__(self, *args, **kwargs):
         self.orderingurlparameter = (
@@ -284,26 +290,20 @@ class BrowseView(BreadView, LoginRequiredMixin, PermissionListMixin, ListView):
         """
         Shortcut to get a Link to a model view.
         The default models views in bread are "read", "edit", "delete".
-        :param modelaction: A model view whose name has been generated with ``bread.utils.urls.model_urlname``
+        :param modelaction: A model view whose name has been generated
+                            with ``bread.utils.urls.model_urlname``
         """
         return Link(
             label="",
-            href=ModelHref(
-                hg.C("row"), modelaction, kwargs={"pk": hg.C("row.pk")}, **kwargs
-            ),
+            href=ModelHref.from_object(hg.C("row"), modelaction, **kwargs),
             iconname=None,
         )
 
     @staticmethod
     def editlink(return_to_current=True):
         return Link(
-            href=ModelHref(
-                hg.C("row"),
-                "edit",
-                kwargs={"pk": hg.C("row.id")},
-                query={"next": hg.C("request.get_full_path")}
-                if return_to_current
-                else {},
+            href=ModelHref.from_object(
+                hg.C("row"), "edit", return_to_current=return_to_current
             ),
             label=_("Edit"),
             iconname="edit",
@@ -312,14 +312,7 @@ class BrowseView(BreadView, LoginRequiredMixin, PermissionListMixin, ListView):
     @staticmethod
     def deletelink(return_to_current=True):
         return Link(
-            href=ModelHref(
-                hg.C("row"),
-                "delete",
-                kwargs={"pk": hg.C("row.id")},
-                query={"next": hg.C("request.get_full_path")}
-                if return_to_current
-                else {},
-            ),
+            href=ModelHref(hg.C("row"), "delete", return_to_current=return_to_current),
             label=_("Delete"),
             iconname="delete",
         )
@@ -336,7 +329,8 @@ def export(queryset, columns):
             or isinstance(column, str)
         ):
             raise ValueError(
-                f"Argument 'columns' needs to be of a list with items of type str or DataTableColumn, but found {column}"
+                "Argument 'columns' needs to be of a list with items of type str "
+                f"or DataTableColumn, but found {column}"
             )
         if isinstance(column, str):
             column = layout.datatable.DataTableColumn(

--- a/bread/views/read.py
+++ b/bread/views/read.py
@@ -57,7 +57,7 @@ class ReadView(
                 style="width: auto",
             ),
             _layout.button.Button(_("Edit"), style="margin-top: 2rem").as_href(
-                ModelHref(self.model, "edit", kwargs={"pk": self.object.pk})
+                ModelHref.from_object(self.object, "edit")
             ),
         )
 


### PR DESCRIPTION
The raw ModelHref is rather inconvenient to use, this should improved creating links to views with object-instances a bit.